### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,7 +40,7 @@ jobs:
           - cc: clang-17
             cxx: clang++-17
             clang_major_version: 17
-            clang_repo_suffix:
+            clang_repo_suffix: -17
             runs-on: ubuntu-22.04
     steps:
       - name: Add Clang/LLVM repositories

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,7 +57,7 @@ jobs:
               clang-${{ matrix.clang_major_version }}
 
       - name: Checkout Git branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 'Configure with CMake'
         run: |-

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,25 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cc: gcc-11
-            cxx: g++-11
-            clang_major_version: null
-            clang_repo_suffix: null
-            runs-on: ubuntu-22.04
           - cc: gcc-12
             cxx: g++-12
             clang_major_version: null
             clang_repo_suffix: null
-            runs-on: ubuntu-22.04
-          - cc: clang-15
-            cxx: clang++-15
-            clang_major_version: 15
-            clang_repo_suffix: -15
-            runs-on: ubuntu-22.04
-          - cc: clang-16
-            cxx: clang++-16
-            clang_major_version: 16
-            clang_repo_suffix: -16
             runs-on: ubuntu-22.04
           - cc: clang-17
             cxx: clang++-17

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,6 +42,11 @@ jobs:
             clang_major_version: 17
             clang_repo_suffix: -17
             runs-on: ubuntu-22.04
+          - cc: clang-18
+            cxx: clang++-18
+            clang_major_version: 18
+            clang_repo_suffix:
+            runs-on: ubuntu-22.04
     steps:
       - name: Add Clang/LLVM repositories
         if: "${{ contains(matrix.cxx, 'clang') }}"


### PR DESCRIPTION
Hi @revmischa,

the CI cron was disabled due to repository inactivity in the meantime — GitHub sends e-mails asking for a veto and the click of a button — and as a result it went unnoticed that the CI is current broken. This pull requests fixes and improves the following:
- Fix compilation with Clang 17
- Add compilation with Clang 18
- Drop compilation with GCC 11, Clang 15, Clang 16
- Bump GitHub Action `actions/checkout` from deprecated version 3 to version 4 (the same way that #3 wants to do).

Could this be merged?

For more details:
- The warnings about the deprecated action can be seen at https://github.com/hartwork/libvisual-projectm/actions/runs/6633330260 (and in a picture below)
- The Clang 17 error can be seen at https://github.com/hartwork/libvisual-projectm/actions/runs/6633304153/job/18020755054 (and in a picture below)

Thanks and best, Sebastian

---

![projectm_checkout_3_Screenshot_20231025_004016](https://github.com/projectM-visualizer/frontend-libvisual-plug-in/assets/1577132/101c5c15-a738-44c0-8866-5f755305fc30)

---

![projectm_clang17_Screenshot_20231025_004138](https://github.com/projectM-visualizer/frontend-libvisual-plug-in/assets/1577132/2b0b5556-9472-48d8-b1f1-2f575ec07bf5)


